### PR TITLE
feat: webaccount authentication tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Add hosts to /etc/hosts
         run: |
-          sudo echo "127.0.0.1 atoolo-e2e-test" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 atoolo-e2e-test www-atoolo-e2e-test ies-atoolo-e2e-test" | sudo tee -a /etc/hosts
 
       - name: Test PHP(${{ matrix.phpVersions }})
         run: MATRIX_PHP_VERSION=${{ matrix.phpVersions }} bin/run.sh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The Solr index is also recreated for each test run, using the resources stored i
 
 The tests themselves are not executed in the container but on the host system. All tests are stored in the [`tests`](tests/) directory.
 
+Host entries are required
+`/etc/hosts`:
+```
+127.0.1.1       atoolo-e2e-test www-atoolo-e2e-test ies-atoolo-e2e-test
+```
+
 ## Endpoints
 
 - Solr: http://localhost:9091/solr/
@@ -32,6 +38,14 @@ To run the tests, the command `bin/run.sh` must be executed.
 ## GraphQL tests
 
 The GraphQL tests are stored in the directory [`test/GraphQL`](tests/GraphQL). Only one test class `Test.php` exists here. This test reads all `*.graphql` files below the directory [`test/GraphQL/resources`](test/GraphQL/resources/) and executes them. In addition to the `*.graphql` file, there must always be a `*.result.json` file in which the expected results are stored.
+
+## Fake IES
+
+To test functions that access the IES server, a fake IES server is required. This runs in the directory `ies-faker` and provides the required routes via a simple PHP script (`index.php`). The IES faker can be accessed internally via the host `ies-atoolo-e2e-test`.
+
+## Supplement Symfony project
+
+The Symfony project created for the tests can, for example, be extended with your own resources that are required for the tests. After installing and setting up the Symfony project, the 'docker/php/app' directory is copied to the Symfony project and the Symfony cache is updated.
 
 ## Debugging
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -26,7 +26,7 @@ else
     export DOCKER_COMPOSE_PROJECT_NAME=atoolo-e2e-test-php${VERSION_AS_NUMBER}
 fi
 
-export ENDPOINT_BASE=http://atoolo-e2e-test:${APACHE_MAPPING_PORT}
+export ENDPOINT_BASE=http://www-atoolo-e2e-test:${APACHE_MAPPING_PORT}
 export MAILPIT_ENDPOINT_BASE=http://atoolo-e2e-test:${MAILPIT_HTTP_MAPPING_PORT}
 
 #docker compose --project-name ${DOCKER_COMPOSE_PROJECT_NAME} build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,9 @@ services:
       SOLR_HOST: solr
       SOLR_PORT: 8983
       IES_WEBNODE_HOME: /srv/sitepark/ies-webnode
+      IES_SCHEME: http
+      IES_HOST: ies-atoolo-e2e-test
+      IES_PORT: 80
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       RESOURCE_ROOT: /var/www/atoolo-e2e-test/www/resources
       MAILER_PORT: 1025
@@ -32,8 +35,10 @@ services:
       #XDEBUG_SESSION: PHPSTORM
     volumes:
       - ./resources:/var/www/atoolo-e2e-test/www/resources
+      - ./ies-faker:/var/www/atoolo-e2e-test/ies
       - ./docker/php/bin:/tools
-      - ./docker/php/etc/apache2/sites-enabled/atoolo-e2e-test.conf:/etc/apache2/sites-enabled/atoolo-e2e-test.conf
+      - ./docker/php/app:/app-files
+      - ./docker/php/etc/apache2/sites-enabled:/etc/apache2/sites-enabled/
       - ./docker/php/etc/ies-webnode/config/realm.properties:/srv/sitepark/ies-webnode/config/realm.properties
       - ./docker/php/etc/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
       - ./data/php/.bash_history:/root/.bash_history

--- a/docker/php/8.2/Dockerfile
+++ b/docker/php/8.2/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-apache
 
 RUN set -ex; \
    apt-get update; \
-   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim; \
+   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim yq; \
    mkdir -p /apps /srv/sitepark/ies-webnode/config; \
    chmod a+rwx /apps /srv/sitepark/ies-webnode/config; \
    rm -rf /var/lib/apt/lists/*;

--- a/docker/php/8.3/Dockerfile
+++ b/docker/php/8.3/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.3-apache
 
 RUN set -ex; \
    apt-get update; \
-   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim; \
+   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim yq; \
    mkdir -p /apps /srv/sitepark/ies-webnode/config; \
    chmod a+rwx /apps /srv/sitepark/ies-webnode/config; \
    rm -rf /var/lib/apt/lists/*;

--- a/docker/php/8.4/Dockerfile
+++ b/docker/php/8.4/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-apache
 
 RUN set -ex; \
    apt-get update; \
-   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim; \
+   apt-get -y --no-install-recommends install git unzip libzip-dev libicu-dev vim yq; \
    mkdir -p /apps /srv/sitepark/ies-webnode/config; \
    chmod a+rwx /apps /srv/sitepark/ies-webnode/config; \
    rm -rf /var/lib/apt/lists/*;

--- a/docker/php/app/src/Controller/TestRoute.php
+++ b/docker/php/app/src/Controller/TestRoute.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TestRoute
+{
+    #[Route('/public-content', name: 'public-content')]
+    public function foo(): Response
+    {
+        return new Response('Public content');
+    }
+
+    #[Route('/protected-content', name: 'protected-content')]
+    public function bar(): Response
+    {
+        return new Response('Protected content');
+    }
+
+    #[Route('/account', name: 'account')]
+    public function account(): Response
+    {
+        return new Response('Please log in to gain access to protected content');
+    }
+
+}

--- a/docker/php/bin/create-cores.sh
+++ b/docker/php/bin/create-cores.sh
@@ -22,6 +22,7 @@ curl -X POST http://$SOLR_HOST:$SOLR_PORT/api/cores -H 'Content-Type: applicatio
   }
 '
 
+echo
 echo create solr core: www-en_US
 curl -X POST http://$SOLR_HOST:$SOLR_PORT/api/cores -H 'Content-Type: application/json' -d '
   {
@@ -31,4 +32,4 @@ curl -X POST http://$SOLR_HOST:$SOLR_PORT/api/cores -H 'Content-Type: applicatio
     }
   }
 '
-
+echo

--- a/docker/php/bin/install-app.sh
+++ b/docker/php/bin/install-app.sh
@@ -64,9 +64,8 @@ composer require --no-interaction \
     atoolo/seo-bundle:dev-main \
     atoolo/rewrite-bundle:dev-main \
     atoolo/microsite-bundle:dev-main \
-    atoolo/webaccount-bundle:dev-main \
+    atoolo/web-account-bundle:dev-main \
     symfony/monolog-bundle
-
 
 ./bin/console lexik:jwt:generate-keypair
 
@@ -79,15 +78,15 @@ yq -i -y '
 | $root.security.providers |= {
 "webnode_users": $root.security.providers.webnode_users,
 "sitekit_users": $root.security.providers.sitekit_users,
-"webaccount_users": {"id": "atoolo_webaccount.user_provider"},
+"web_account_users": {"id": "atoolo_web_account.user_provider"},
 "all_users": $root.security.providers.all_users
 }
-| .security.providers.all_users.chain.providers += ["webaccount_users"]
-| .security.firewalls.webaccount = {
+| .security.providers.all_users.chain.providers += ["web_account_users"]
+| .security.firewalls.web_account = {
 "lazy": true,
-"provider": "webaccount_users",
-"custom_authenticators": ["atoolo_webaccount.authenticator"],
-"entry_point": "atoolo_webaccount.unauthorized_entry_point",
+"provider": "web_account_users",
+"custom_authenticators": ["atoolo_web_account.authenticator"],
+"entry_point": "atoolo_web_account.unauthorized_entry_point",
 "stateless": false
 }
 | .security.access_control |= (

--- a/docker/php/etc/apache2/sites-enabled/ies-faker-atoolo-e2e-test.conf
+++ b/docker/php/etc/apache2/sites-enabled/ies-faker-atoolo-e2e-test.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+        ServerName ies-atoolo-e2e-test
+
+        ErrorLog        /var/log/apache2/ies-atoolo-e2e-test.err.log
+        CustomLog       /var/log/apache2/ies-atoolo-e2e-test.access.log combined
+
+        DocumentRoot /var/www/atoolo-e2e-test/ies
+        <Directory /var/www/atoolo-e2e-test/ies>
+            AllowOverride None
+            Require all granted
+            FallbackResource /index.php
+        </Directory>
+
+</VirtualHost>

--- a/docker/php/etc/apache2/sites-enabled/www-atoolo-e2e-test.conf
+++ b/docker/php/etc/apache2/sites-enabled/www-atoolo-e2e-test.conf
@@ -1,8 +1,8 @@
 <VirtualHost *:80>
-        ServerName atoolo-e2e-test
+        ServerName www-atoolo-e2e-test
 
-        ErrorLog        /var/log/apache2/atoolo-e2e-test.err.log
-        CustomLog       /var/log/apache2/atoolo-e2e-test.access.log combined
+        ErrorLog        /var/log/apache2/www-atoolo-e2e-test.err.log
+        CustomLog       /var/log/apache2/www-atoolo-e2e-test.access.log combined
 
         DocumentRoot /var/www/atoolo-e2e-test/www/app/public
         <Directory /var/www/atoolo-e2e-test/www/app/public>

--- a/ies-faker/index.php
+++ b/ies-faker/index.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+function json_response($data, int $status = 200): void {
+    http_response_code($status);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+    exit;
+}
+
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+$body = file_get_contents('php://input');
+
+$routes = [
+    [
+        'method' => 'POST',
+        'path'   => '#^/api/graphql#',
+        'body'   => '#.*mutation authenticate.*#',
+        'handler' => static function ($matches) {
+            json_response([
+                'data' => [
+                    'security' => [
+                        'authenticate' => [
+                            'withPassword' => [
+                                'status' => 'SUCCESS',
+                                'user' => [
+                                    'id' => '123',
+                                    'username' => 'peterpan',
+                                    'firstName' => 'Peter',
+                                    'lastName' => 'Pan',
+                                    'email' => 'peterpan@neverland.com',
+                                    'roles' => ['A', 'B'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        },
+    ],
+];
+
+foreach ($routes as $route) {
+    if (
+        $method === $route['method']
+        && preg_match($route['path'], $path, $matches)
+        && ($route['body'] === null || preg_match($route['body'], $body))
+    ) {
+        $route['handler']($matches);
+        exit;
+    }
+}
+
+// Fallback 404
+http_response_code(404);
+echo "Not Found " . $path;

--- a/resources/context.php
+++ b/resources/context.php
@@ -14,7 +14,7 @@
         "id" => 1,
         "anchor" => "www",
         "name" => "Atoolo E2E test",
-        "serverName" => "atoolo-e2e-test",
+        "serverName" => "www-atoolo-e2e-test",
         "serverAliases" => [],
         "preview" => false,
         "nature" => "internet",

--- a/test/WebAccount/Test.php
+++ b/test/WebAccount/Test.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\E2E\Test\WebAccount;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\RedirectionException;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+class Test extends TestCase
+{
+    private static string $ENDPOINT_BASE;
+
+    public static function setUpBeforeClass(): void
+    {
+        // from phpunit.xml
+        self::$ENDPOINT_BASE = $_SERVER['ENDPOINT_BASE'];
+    }
+
+    public function testPublicRequest(): void
+    {
+        $client = HttpClient::create();
+
+        $response = $client->request(
+            'GET',
+            self::$ENDPOINT_BASE . '/public-content',
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Public request failed');
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testProtectedUnauthorizedRequest(): void
+    {
+        $client = HttpClient::create();
+
+        $response = $client->request(
+            'GET',
+            self::$ENDPOINT_BASE . '/protected-content',
+            [
+                'max_redirects' => 0,
+            ],
+        );
+
+        if ($response->getStatusCode() !== 302) {
+            $this->fail("Protected request should redirect to the login page without authentication:\n"
+                . "Status code: " . $response->getStatusCode() . "\n"
+                . "Response: " . $response->getContent(false));
+        }
+
+        # Header must be determined via getInfo(), otherwise a RedirectException will be thrown
+        $location = $response->getInfo('redirect_url');
+
+        $this->assertEquals(
+            self::$ENDPOINT_BASE . '/account',
+            $location,
+            'Protected request should redirect to the login page',
+        );
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testProtectedAuthorizedRequest(): void
+    {
+        $client = HttpClient::create();
+
+        $query = <<<'GRAPHQL'
+mutation webaccountAuthenticationWithPassword($username: String!, $password: String!) {
+  webaccountAuthenticationWithPassword(
+    username: $username
+    password: $password
+    setJwtCookie: true
+  ) {
+    status
+    user {
+      id
+      username
+      firstName
+      lastName
+      email
+      roles
+    }
+  }
+}
+GRAPHQL;
+
+        $variables = [
+            'username' => 'peterpan',
+            'password' => 'tinkabell',
+        ];
+
+        $payload = ['query' => $query, 'variables' => $variables];
+
+        $authResponse = $client->request(
+            'POST',
+            self::$ENDPOINT_BASE . '/api/graphql/',
+            [
+                'json' => $payload,
+            ],
+        );
+
+        $authResponseData = $authResponse->toArray();
+
+        if (isset($authResponseData['errors'])) {
+            $this->fail(
+                'Authentication failed: ' . $authResponseData['errors'][0]['message'] .
+                "\nDebug message: " . $authResponseData['errors'][0]['extensions']['debugMessage'],
+            );
+        }
+
+        $setCookieHeader = $authResponse->getHeaders()['set-cookie'] ??= [];
+
+        $response = $client->request(
+            'GET',
+            self::$ENDPOINT_BASE . '/protected-content',
+            [
+                'headers' => [
+                    'Cookie' => $setCookieHeader,
+                ],
+            ],
+        );
+        if ($response->getStatusCode() !== 200) {
+            $this->fail("Protected request should be successful:\n"
+                . "Status code: " . $response->getStatusCode() . "\n"
+                . "Response: " . $response->getContent(false));
+        }
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Protected request should be successful');
+    }
+
+}

--- a/test/WebAccount/Test.php
+++ b/test/WebAccount/Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Atoolo\E2E\Test\WebAccount;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -81,8 +80,8 @@ class Test extends TestCase
         $client = HttpClient::create();
 
         $query = <<<'GRAPHQL'
-mutation webaccountAuthenticationWithPassword($username: String!, $password: String!) {
-  webaccountAuthenticationWithPassword(
+mutation webAccountAuthenticationWithPassword($username: String!, $password: String!) {
+  webAccountAuthenticationWithPassword(
     username: $username
     password: $password
     setJwtCookie: true

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 include __DIR__ . '/../vendor/autoload.php';
 
-$_SERVER['ENDPOINT_BASE'] = $_SERVER['ENDPOINT_BASE'] ?? 'http://atoolo-e2e-test:9090';
+$_SERVER['ENDPOINT_BASE'] = $_SERVER['ENDPOINT_BASE'] ?? 'http://www-atoolo-e2e-test:9090';
 $_SERVER['MAILPIT_ENDPOINT_BASE'] = $_SERVER['MAILPIT_ENDPOINT_BASE'] ?? 'http://atoolo-e2e-test:8025';
 $_SERVER['DOCKER_COMPOSE_PROJECT_NAME'] = $_SERVER['DOCKER_COMPOSE_PROJECT_NAME'] ?? 'atoolo-e2e-test';
 


### PR DESCRIPTION
To be able to test the web account authentication, the test environment had to be extended: 

1. **IES-Faker**: Routes are defined for certain requests to the IES that give a defined response.
2. **Extensibility of the Symfony test project**: A folder is now provided here that can be used to add files to the project. For example, to define new routes.