### PR TITLE
ci: replace deprecated Node.js 20 actions with Node.js 24 versions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: E2E Tests (PHP ${{ matrix.phpVersions }})
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install PHP ${{ matrix.phpVersions }}
         uses: shivammathur/setup-php@v2
@@ -22,7 +22,7 @@ jobs:
           tools: composer, phive
 
       - name: "Cache tools installed with PHIVE (PHP ${{ matrix.phpVersions }})"
-        uses: "actions/cache@v3"
+        uses: "actions/cache@v5"
         with:
           path: "${{ runner.temp }}/.phive"
           key: "php-phive-${{ hashFiles('.phive/phars.xml') }}"


### PR DESCRIPTION
hi sitepark-veltrup,

i have this failure with the pipeline:

verify / Composer Verify (PHP 8.1)
(https://github.com/sitepark/atoolo-crawler-teaser-indexer/actions/runs/27549710118/job/81432404897#step:31:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/cache@v4, actions/checkout@v4, actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/